### PR TITLE
Add set metrics

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/vladabroz/go-ipset
+module github.com/intuitivelabs/go-ipset
 
 go 1.15
 

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -260,19 +260,19 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 		}
 		switch values[0] {
 		case "Type":
-			stats.Type = values[1]
+			stats.Type = strings.Trim(values[1], " ")
 		case "Size in memory":
-			stats.Size, err = strconv.ParseUint(values[1], 10, 64)
+			stats.Size, err = strconv.ParseUint(strings.Trim(values[1], " "), 10, 64)
 			if err != nil {
 				return
 			}
 		case "References":
-			stats.Refs, err = strconv.ParseUint(values[1], 10, 64)
+			stats.Refs, err = strconv.ParseUint(strings.Trim(values[1], " "), 10, 64)
 			if err != nil {
 				return
 			}
 		case "Number of entries":
-			stats.Entries, err = strconv.ParseUint(values[1], 10, 64)
+			stats.Entries, err = strconv.ParseUint(strings.Trim(values[1], " "), 10, 64)
 			if err != nil {
 				return
 			}

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -246,6 +246,9 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 	if err != nil {
 		return
 	}
+	if len(info) == 0 {
+		return
+	}
 	// split on white spaces
 	for _, l := range strings.Fields(info[0]) {
 		// split on ":"

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -254,7 +254,7 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 	for _, l := range info {
 		// split on ":"
 		values := strings.Split(l, ":")
-		fmt.Printf("l: %s values: %v\n", l, info)
+		fmt.Printf("l: %s values: %v\n", l, values)
 		if len(values) == 0 {
 			continue
 		}
@@ -262,17 +262,17 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 		case "Type":
 			stats.Type = values[1]
 		case "Size in memory":
-			stats.Size, err = strconv.ParseUint(values[1], 0, 64)
+			stats.Size, err = strconv.ParseUint(values[1], 10, 64)
 			if err != nil {
 				return
 			}
 		case "References":
-			stats.Refs, err = strconv.ParseUint(values[1], 0, 64)
+			stats.Refs, err = strconv.ParseUint(values[1], 10, 64)
 			if err != nil {
 				return
 			}
 		case "Number of entries":
-			stats.Entries, err = strconv.ParseUint(values[1], 0, 64)
+			stats.Entries, err = strconv.ParseUint(values[1], 10, 64)
 			if err != nil {
 				return
 			}

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -246,6 +246,7 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 	if err != nil {
 		return
 	}
+	fmt.Printf("info: %v\n", info)
 	if len(info) == 0 {
 		return
 	}

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -282,10 +282,8 @@ func loadStats(stats *Stats, key, val string) error {
 func parseListTerse(details []string) (stats Stats, err error) {
 	// split on white spaces
 	for _, l := range details {
-		fmt.Println("l:", l)
 		// split on ":"
 		values := strings.Split(l, ":")
-		fmt.Println("values:", values)
 		if len(values) < 2 {
 			continue
 		}

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -246,7 +246,6 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 	if err != nil {
 		return
 	}
-	fmt.Printf("info: %v\n", info)
 	if len(info) == 0 {
 		return
 	}
@@ -254,7 +253,6 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 	for _, l := range info {
 		// split on ":"
 		values := strings.Split(l, ":")
-		fmt.Printf("l: %s values: %v\n", l, values)
 		if len(values) == 0 {
 			continue
 		}
@@ -377,10 +375,6 @@ func listWithOpts(set string, opts ...string) ([]string, error) {
 	out, err := exec.Command(ipsetPath, cmd...).CombinedOutput()
 	if err != nil {
 		return []string{}, fmt.Errorf("error listing set %s: %v (%s)", set, err, out)
-	}
-	fmt.Println(string(out[:]))
-	for _, s := range strings.Split(string(out[:]), "\n") {
-		fmt.Println(s)
 	}
 	return strings.Split(string(out[:]), "\n"), nil
 }

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -377,13 +377,10 @@ func listWithOpts(set string, opts ...string) ([]string, error) {
 		return []string{}, fmt.Errorf("error listing set %s: %v (%s)", set, err, out)
 	}
 	fmt.Println(string(out[:]))
-	for _, s := range strings.Fields(string(out[:])) {
+	for _, s := range strings.Split(string(out[:]), "\n") {
 		fmt.Println(s)
 	}
-	for _, s := range strings.FieldsFunc(string(out[:]), fieldsFunc) {
-		fmt.Println(s)
-	}
-	return strings.FieldsFunc(string(out[:]), fieldsFunc), nil
+	return strings.Split(string(out[:]), "\n"), nil
 }
 
 func getIpsetSupportedVersion() (bool, error) {

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -377,6 +377,12 @@ func listWithOpts(set string, opts ...string) ([]string, error) {
 		return []string{}, fmt.Errorf("error listing set %s: %v (%s)", set, err, out)
 	}
 	fmt.Println(string(out[:]))
+	for _, s := range strings.Fields(string(out[:])) {
+		fmt.Println(s)
+	}
+	for _, s := range strings.FieldsFunc(string(out[:]), fieldsFunc) {
+		fmt.Println(s)
+	}
 	return strings.FieldsFunc(string(out[:]), fieldsFunc), nil
 }
 

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -282,6 +282,7 @@ func loadStats(stats *Stats, key, val string) error {
 func parseListTerse(details []string) (stats Stats, err error) {
 	// split on white spaces
 	for _, l := range details {
+		fmt.Println(l)
 		// split on ":"
 		values := strings.Split(l, ":")
 		if len(values) == 0 {

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -286,7 +286,7 @@ func parseListTerse(details []string) (stats Stats, err error) {
 		// split on ":"
 		values := strings.Split(l, ":")
 		fmt.Println("values:", values)
-		if len(values) < 1 {
+		if len(values) < 2 {
 			continue
 		}
 		// remove the blanks

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -377,9 +377,7 @@ func listWithOpts(set string, opts ...string) ([]string, error) {
 		return []string{}, fmt.Errorf("error listing set %s: %v (%s)", set, err, out)
 	}
 	fmt.Println(string(out[:]))
-	r := regexp.MustCompile("(?m)^(.*\n)*Members:\n")
-	newlist := r.ReplaceAllString(string(out[:]), "")
-	return strings.FieldsFunc(newlist, fieldsFunc), nil
+	return strings.FieldsFunc(string(out[:]), fieldsFunc), nil
 }
 
 func getIpsetSupportedVersion() (bool, error) {

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -372,10 +372,11 @@ func listWithOpts(set string, opts ...string) ([]string, error) {
 	}
 	cmd = append(cmd, "list")
 	cmd = append(cmd, set)
-	out, err := exec.Command(ipsetPath, "list", set).CombinedOutput()
+	out, err := exec.Command(ipsetPath, cmd...).CombinedOutput()
 	if err != nil {
 		return []string{}, fmt.Errorf("error listing set %s: %v (%s)", set, err, out)
 	}
+	fmt.Println(out)
 	r := regexp.MustCompile("(?m)^(.*\n)*Members:\n")
 	newlist := r.ReplaceAllString(string(out[:]), "")
 	return strings.FieldsFunc(newlist, fieldsFunc), nil

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -282,9 +282,10 @@ func loadStats(stats *Stats, key, val string) error {
 func parseListTerse(details []string) (stats Stats, err error) {
 	// split on white spaces
 	for _, l := range details {
-		fmt.Println(l)
+		fmt.Println("l:", l)
 		// split on ":"
 		values := strings.Split(l, ":")
+		fmt.Println("values:", values)
 		if len(values) == 0 {
 			continue
 		}

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -376,7 +376,7 @@ func listWithOpts(set string, opts ...string) ([]string, error) {
 	if err != nil {
 		return []string{}, fmt.Errorf("error listing set %s: %v (%s)", set, err, out)
 	}
-	fmt.Println(out)
+	fmt.Println(string(out[:]))
 	r := regexp.MustCompile("(?m)^(.*\n)*Members:\n")
 	newlist := r.ReplaceAllString(string(out[:]), "")
 	return strings.FieldsFunc(newlist, fieldsFunc), nil

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -251,9 +251,10 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 		return
 	}
 	// split on white spaces
-	for _, l := range strings.Fields(info[0]) {
+	for _, l := range info {
 		// split on ":"
 		values := strings.Split(l, ":")
+		fmt.Printf("values: %v\n", info)
 		if len(values) == 0 {
 			continue
 		}

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -286,7 +286,7 @@ func parseListTerse(details []string) (stats Stats, err error) {
 		// split on ":"
 		values := strings.Split(l, ":")
 		fmt.Println("values:", values)
-		if len(values) == 0 {
+		if len(values) < 1 {
 			continue
 		}
 		// remove the blanks

--- a/ipset/ipset.go
+++ b/ipset/ipset.go
@@ -254,25 +254,25 @@ func (s *IPSet) Statistics() (stats Stats, err error) {
 	for _, l := range info {
 		// split on ":"
 		values := strings.Split(l, ":")
-		fmt.Printf("values: %v\n", info)
+		fmt.Printf("l: %s values: %v\n", l, info)
 		if len(values) == 0 {
 			continue
 		}
 		switch values[0] {
 		case "Type":
-			stats.Type = values[2]
+			stats.Type = values[1]
 		case "Size in memory":
-			stats.Size, err = strconv.ParseUint(values[2], 0, 64)
+			stats.Size, err = strconv.ParseUint(values[1], 0, 64)
 			if err != nil {
 				return
 			}
 		case "References":
-			stats.Refs, err = strconv.ParseUint(values[2], 0, 64)
+			stats.Refs, err = strconv.ParseUint(values[1], 0, 64)
 			if err != nil {
 				return
 			}
 		case "Number of entries":
-			stats.Entries, err = strconv.ParseUint(values[2], 0, 64)
+			stats.Entries, err = strconv.ParseUint(values[1], 0, 64)
 			if err != nil {
 				return
 			}


### PR DESCRIPTION
Provide metrics per set. Metrics are obtained by using the output of the `ipset -t list` which is parsed and loaded into a struct.
